### PR TITLE
'add_child' use child type instead of factory type

### DIFF
--- a/nutree/node.py
+++ b/nutree/node.py
@@ -546,7 +546,7 @@ class Node:
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
 
-            # If creating an inherited node, use the parent class as constructor instead of default factory
+            # If creating an inherited node, use the parent class as constructor
             child_class = child.__class__
 
             node = child_class(

--- a/nutree/node.py
+++ b/nutree/node.py
@@ -545,10 +545,10 @@ class Node:
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            
+
             # If creating an inherited node, use the parent class as constructor instead of default factory
             child_class = child.__class__
-            
+
             node = child_class(
                 source_node.data, parent=self, data_id=data_id, node_id=node_id
             )

--- a/nutree/node.py
+++ b/nutree/node.py
@@ -545,7 +545,11 @@ class Node:
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            node = factory(
+            
+            # If creating an inherited node, use the parent class as constructor instead of default factory
+            child_class = child.__class__
+            
+            node = child_class(
                 source_node.data, parent=self, data_id=data_id, node_id=node_id
             )
         else:

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -266,10 +266,10 @@ class TypedNode(Node):
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            
+
             # If creating an inherited node, use the parent class as constructor instead of default factory
             child_class = child.__class__
-            
+
             node = child_class(
                 kind,
                 source_node.data,

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -267,7 +267,7 @@ class TypedNode(Node):
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
 
-            # If creating an inherited node, use the parent class as constructor instead of default factory
+            # If creating an inherited node, use the parent class as constructor
             child_class = child.__class__
 
             node = child_class(

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -266,7 +266,11 @@ class TypedNode(Node):
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            node = factory(
+            
+            # If creating an inherited node, use the parent class as constructor instead of default factory
+            child_class = child.__class__
+            
+            node = child_class(
                 kind,
                 source_node.data,
                 parent=self,


### PR DESCRIPTION
Changed the logic for when adding a node inside of Node.add_child and TypedNode.add_child to use the given Nodes class (providing support for extending the Node class) instead of deriving the class from the default factory.

If the child has been checked to ensure it is a Node instance, there is no reason to use the default factory, rather use the class of the given Node, as it may differ from the default node factory.

All tests pass.