### PR TITLE
'factory' parameter in 'add_child'

### DIFF
--- a/nutree/node.py
+++ b/nutree/node.py
@@ -468,6 +468,7 @@ class Node:
         deep: bool = None,
         data_id=None,
         node_id=None,
+        factory: "Node" = None,
     ) -> "Node":
         """Append or insert a new subnode or branch as child.
 
@@ -528,7 +529,7 @@ class Node:
             return
 
         source_node = None
-        factory = self._tree._node_factory
+        factory = factory or self._tree._node_factory
         if isinstance(child, Node):
             if deep is None:
                 deep = False

--- a/nutree/node.py
+++ b/nutree/node.py
@@ -546,7 +546,7 @@ class Node:
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
 
-            # If creating an inherited node, use the parent class as constructor instead of default factory
+            # If creating an inherited node, use the parent class as constructor
             child_class = child.__class__
 
             node = child_class(

--- a/nutree/node.py
+++ b/nutree/node.py
@@ -545,10 +545,10 @@ class Node:
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            
+
             # If creating an inherited node, use the parent class as constructor instead of default factory
             child_class = child.__class__
-            
+
             node = child_class(
                 source_node.data, parent=self, data_id=data_id, node_id=node_id
             )

--- a/nutree/node.py
+++ b/nutree/node.py
@@ -545,7 +545,11 @@ class Node:
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            node = factory(
+            
+            # If creating an inherited node, use the parent class as constructor instead of default factory
+            child_class = child.__class__
+            
+            node = child_class(
                 source_node.data, parent=self, data_id=data_id, node_id=node_id
             )
         else:

--- a/nutree/tree.py
+++ b/nutree/tree.py
@@ -269,6 +269,7 @@ class Tree:
         deep: bool = None,
         data_id=None,
         node_id=None,
+        factory: "Node" = None,
     ) -> "Node":
         """Add a toplevel node.
 
@@ -280,6 +281,7 @@ class Tree:
             deep=deep,
             data_id=data_id,
             node_id=node_id,
+            factory=factory,
         )
 
     #: Alias for :meth:`add_child`

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -266,10 +266,10 @@ class TypedNode(Node):
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            
+
             # If creating an inherited node, use the parent class as constructor instead of default factory
             child_class = child.__class__
-            
+
             node = child_class(
                 kind,
                 source_node.data,

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -224,6 +224,7 @@ class TypedNode(Node):
         deep: bool = None,
         data_id=None,
         node_id=None,
+        factory: "Node" = None,
     ) -> "TypedNode":
         """See ..."""
         # assert not isinstance(child, TypedNode) or child.kind == self.kind
@@ -249,7 +250,7 @@ class TypedNode(Node):
             return
 
         source_node = None
-        factory = self._tree._node_factory
+        factory = factory or self._tree._node_factory
         if isinstance(child, Node):  # TypedNode):
             if deep is None:
                 deep = False

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -267,7 +267,7 @@ class TypedNode(Node):
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
 
-            # If creating an inherited node, use the parent class as constructor instead of default factory
+            # If creating an inherited node, use the parent class as constructor
             child_class = child.__class__
 
             node = child_class(

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -266,7 +266,11 @@ class TypedNode(Node):
                 # raise NotImplementedError("Cross-tree adding")
             if data_id and data_id != source_node._data_id:
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
-            node = factory(
+            
+            # If creating an inherited node, use the parent class as constructor instead of default factory
+            child_class = child.__class__
+            
+            node = child_class(
                 kind,
                 source_node.data,
                 parent=self,

--- a/nutree/typed_tree.py
+++ b/nutree/typed_tree.py
@@ -3,7 +3,7 @@
 """
 Declare the :class:`~nutree.tree.TypedTree` class.
 """
-from typing import Any, Dict, Generator, List, Union
+from typing import Any, Dict, Generator, List, Type, Union
 
 from nutree.common import (
     IterMethod,
@@ -224,7 +224,7 @@ class TypedNode(Node):
         deep: bool = None,
         data_id=None,
         node_id=None,
-        factory: "Node" = None,
+        factory: Type["Node"] = None,
     ) -> "TypedNode":
         """See ..."""
         # assert not isinstance(child, TypedNode) or child.kind == self.kind
@@ -250,7 +250,6 @@ class TypedNode(Node):
             return
 
         source_node = None
-        factory = factory or self._tree._node_factory
         if isinstance(child, Node):  # TypedNode):
             if deep is None:
                 deep = False
@@ -269,9 +268,9 @@ class TypedNode(Node):
                 raise UniqueConstraintError(f"data_id conflict: {source_node}")
 
             # If creating an inherited node, use the parent class as constructor
-            child_class = child.__class__
+            node_class = factory or child.__class__
 
-            node = child_class(
+            node = node_class(
                 kind,
                 source_node.data,
                 parent=self,
@@ -279,7 +278,9 @@ class TypedNode(Node):
                 node_id=node_id,
             )
         else:
-            node = factory(kind, child, parent=self, data_id=data_id, node_id=node_id)
+            node = (factory or self._tree._node_factory)(
+                kind, child, parent=self, data_id=data_id, node_id=node_id
+            )
 
         children = self._children
         if children is None:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -72,8 +72,27 @@ class TestBasics:
         books = tree.add_child("Books", factory=CustomNode)
         assert isinstance(books, CustomNode)
 
-        books.add_child("Harry Potter", factory=CustomNode)
+        node = books.add_child("Harry Potter", factory=CustomNode)
+        assert isinstance(node, CustomNode)
+
+    def test_custom_class_factory_override_add_child(self):
+        tree = Tree("fixture")
+
+        class CustomNode(Node):
+            ...
+
+        class SpoofNode(Node):
+            ...
+
+        books = tree.add_child(
+            SpoofNode("Books", parent=tree._root), factory=CustomNode
+        )
         assert isinstance(books, CustomNode)
+
+        node = books.add_child(
+            SpoofNode("Harry Potter", parent=books), factory=CustomNode
+        )
+        assert isinstance(node, CustomNode)
 
     def test_meta(aelf):
         tree = fixture.create_tree()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -63,6 +63,18 @@ class TestBasics:
         #     print(tree.format(repr="{node.data}", style=style))
         # raise
 
+    def test_custom_class_add_child(self):
+        tree = Tree("fixture")
+
+        class CustomNode(Node):
+            ...
+
+        books = tree.add_child("Books", factory=CustomNode)
+        assert isinstance(books, CustomNode)
+
+        books.add_child("Harry Potter", factory=CustomNode)
+        assert isinstance(books, CustomNode)
+
     def test_meta(aelf):
         tree = fixture.create_tree()
         node = tree.first_child()


### PR DESCRIPTION
Added factory parameter to add_child method to allow for different factory types throughout the tree. Previous PR allowed for support for custom class in deep-copying of trees, this PR allows manual creation of children with differing factory types.

Added test 'test_custom_class_add_child' to validate new functionality.

p.s. I cannot promise that I will stop bugging you with PR's